### PR TITLE
refactor: `application.yml` 관련 gitignore 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ out/
 !**/src/main/http/
 
 ### spring applicaiton setting
-application.yml
+src/**/application-*.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3307/FASTBOARD?serverTimezone=Asia/Seoul
-    username: root
-    password: 1234
-  jpa:
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-        hbm2ddl:
-          auto: create
+  profiles:
+    active:
+      - dev


### PR DESCRIPTION
개발 환경과 실행환경을 분리하기 위해서 `application.yml`을 다음과 같이 수정했습니다:

```
# application.yml
spring:
  profiles:
    active:
      - dev
```

위와 같이 내용을 수정하면 spring에서 자동으로 위 설정과 맞는 설정파일을 찾아서 그 설정파일을 불러옵니다.

## 예시)

- 위 코드에서 dev로 설정 : `application-dev.yml`을 불러와서 실행
- 위 코드에서 prod로 설정 : `application-prod.yml` 불러와서 실행